### PR TITLE
feat: make tools multi sports

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,7 +13,8 @@
       "Bash(ls node_modules/@expo-google-fonts/inter/*.js)",
       "Bash(sed -i '' 's/fontFamily: '\\\\''BarlowCondensedBold'\\\\''/fontFamily: '\\\\''InterBold'\\\\''/g' /Users/iCherya/Front-end/Projects/sportik/src/onboarding/Onboarding.tsx)",
       "Bash(sed -i '' 's/fontFamily: '\\\\''BarlowSemiBold'\\\\''/fontFamily: '\\\\''InterSemiBold'\\\\''/g' /Users/iCherya/Front-end/Projects/sportik/src/overlays/EditProfileOverlay.tsx)",
-      "Bash(sed -i '' 's/fontFamily: '\\\\''Barlow'\\\\''/fontFamily: '\\\\''Inter'\\\\''/g' /Users/iCherya/Front-end/Projects/sportik/src/tools/PoolCounter.tsx /Users/iCherya/Front-end/Projects/sportik/src/overlays/PRDetail.tsx /Users/iCherya/Front-end/Projects/sportik/src/screens/AccountScreen.tsx /Users/iCherya/Front-end/Projects/sportik/src/screens/EventsScreen.tsx)"
+      "Bash(sed -i '' 's/fontFamily: '\\\\''Barlow'\\\\''/fontFamily: '\\\\''Inter'\\\\''/g' /Users/iCherya/Front-end/Projects/sportik/src/tools/PoolCounter.tsx /Users/iCherya/Front-end/Projects/sportik/src/overlays/PRDetail.tsx /Users/iCherya/Front-end/Projects/sportik/src/screens/AccountScreen.tsx /Users/iCherya/Front-end/Projects/sportik/src/screens/EventsScreen.tsx)",
+      "Bash(echo \"exit: $?\")"
     ]
   }
 }

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -18,9 +18,8 @@ export type Tool = {
   id: string;
   nameKey: LangKey;
   descKey: LangKey;
-  sport: SportKey | 'all';
+  sports: SportKey[];
   icon: string;
-  tag: string;
 };
 
 export type Session = {
@@ -210,117 +209,19 @@ export const EVENTS_DATA: Event[] = [
 ];
 
 export const TOOLS: Tool[] = [
-  {
-    id: 'pace',
-    nameKey: 'tool_pace',
-    descKey: 'tool_pace_desc',
-    sport: 'run',
-    icon: '⏱',
-    tag: 'Run',
-  },
-  {
-    id: 'predict',
-    nameKey: 'tool_predict',
-    descKey: 'tool_predict_desc',
-    sport: 'run',
-    icon: '📈',
-    tag: 'Run',
-  },
-  {
-    id: 'cadence',
-    nameKey: 'tool_cadence',
-    descKey: 'tool_cadence_desc',
-    sport: 'all',
-    icon: '🎵',
-    tag: 'All',
-  },
-  {
-    id: 'power',
-    nameKey: 'tool_power',
-    descKey: 'tool_power_desc',
-    sport: 'bike',
-    icon: '⚡',
-    tag: 'Bike',
-  },
-  {
-    id: 'speed',
-    nameKey: 'tool_speed',
-    descKey: 'tool_speed_desc',
-    sport: 'bike',
-    icon: '🚴',
-    tag: 'Bike',
-  },
-  { id: 'hr', nameKey: 'tool_hr', descKey: 'tool_hr_desc', sport: 'all', icon: '❤️', tag: 'All' },
-  {
-    id: 'calorie',
-    nameKey: 'tool_calorie',
-    descKey: 'tool_calorie_desc',
-    sport: 'all',
-    icon: '🔥',
-    tag: 'All',
-  },
-  {
-    id: 'swolf',
-    nameKey: 'tool_swolf',
-    descKey: 'tool_swolf_desc',
-    sport: 'swim',
-    icon: '🏊',
-    tag: 'Swim',
-  },
-  {
-    id: 'pool',
-    nameKey: 'tool_pool',
-    descKey: 'tool_pool_desc',
-    sport: 'swim',
-    icon: '🏁',
-    tag: 'Swim',
-  },
-  {
-    id: 'wetsuit',
-    nameKey: 'tool_wetsuit',
-    descKey: 'tool_wetsuit_desc',
-    sport: 'swim',
-    icon: '🌡️',
-    tag: 'Swim',
-  },
-  {
-    id: 'split',
-    nameKey: 'tool_split',
-    descKey: 'tool_split_desc',
-    sport: 'tri',
-    icon: '🔱',
-    tag: 'Tri',
-  },
-  {
-    id: 'nutrition',
-    nameKey: 'tool_nutrition',
-    descKey: 'tool_nutrition_desc',
-    sport: 'tri',
-    icon: '🍌',
-    tag: 'Tri',
-  },
-  {
-    id: 'transition',
-    nameKey: 'tool_transition',
-    descKey: 'tool_transition_desc',
-    sport: 'tri',
-    icon: '🔄',
-    tag: 'Tri',
-  },
-  {
-    id: 'checklist',
-    nameKey: 'tool_checklist',
-    descKey: 'tool_checklist_desc',
-    sport: 'tri',
-    icon: '✅',
-    tag: 'Tri',
-  },
-  {
-    id: 'taper',
-    nameKey: 'tool_taper',
-    descKey: 'tool_taper_desc',
-    sport: 'tri',
-    icon: '📉',
-    tag: 'Tri',
-  },
+  { id: 'pace',       nameKey: 'tool_pace',       descKey: 'tool_pace_desc',       sports: ['run'],                      icon: '⏱'  },
+  { id: 'predict',    nameKey: 'tool_predict',    descKey: 'tool_predict_desc',    sports: ['run'],                      icon: '📈'  },
+  { id: 'cadence',    nameKey: 'tool_cadence',    descKey: 'tool_cadence_desc',    sports: ['run', 'bike'],              icon: '🎵'  },
+  { id: 'power',      nameKey: 'tool_power',      descKey: 'tool_power_desc',      sports: ['bike'],                     icon: '⚡'  },
+  { id: 'speed',      nameKey: 'tool_speed',      descKey: 'tool_speed_desc',      sports: ['bike'],                     icon: '🚴'  },
+  { id: 'hr',         nameKey: 'tool_hr',         descKey: 'tool_hr_desc',         sports: ['run', 'bike', 'swim', 'tri'], icon: '❤️' },
+  { id: 'calorie',    nameKey: 'tool_calorie',    descKey: 'tool_calorie_desc',    sports: ['run', 'bike', 'swim', 'tri'], icon: '🔥' },
+  { id: 'swolf',      nameKey: 'tool_swolf',      descKey: 'tool_swolf_desc',      sports: ['swim'],                     icon: '🏊'  },
+  { id: 'pool',       nameKey: 'tool_pool',       descKey: 'tool_pool_desc',       sports: ['swim'],                     icon: '🏁'  },
+  { id: 'wetsuit',    nameKey: 'tool_wetsuit',    descKey: 'tool_wetsuit_desc',    sports: ['swim'],                     icon: '🌡️' },
+  { id: 'split',      nameKey: 'tool_split',      descKey: 'tool_split_desc',      sports: ['tri'],                      icon: '🔱'  },
+  { id: 'nutrition',  nameKey: 'tool_nutrition',  descKey: 'tool_nutrition_desc',  sports: ['tri'],                      icon: '🍌'  },
+  { id: 'transition', nameKey: 'tool_transition', descKey: 'tool_transition_desc', sports: ['tri'],                      icon: '🔄'  },
+  { id: 'checklist',  nameKey: 'tool_checklist',  descKey: 'tool_checklist_desc',  sports: ['tri'],                      icon: '✅'  },
+  { id: 'taper',      nameKey: 'tool_taper',      descKey: 'tool_taper_desc',      sports: ['tri'],                      icon: '📉'  },
 ];

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,5 +1,18 @@
 import type { LangKey } from '../i18n';
-import type { SportKey } from '../theme';
+import { Sports, type SportKey } from '../theme';
+
+/** Every concrete sport key (excludes synthetic 'all'). Derive from Sports so additions are automatic. */
+export const ALL_SPORT_KEYS = Object.keys(Sports).filter((k) => k !== 'all') as SportKey[];
+
+/** True when a tool covers every sport (shown as "All" badge). */
+export function isAllSports(tool: { sports: SportKey[] }): boolean {
+  return ALL_SPORT_KEYS.every((s) => tool.sports.includes(s));
+}
+
+/** Primary accent color for a tool: first sport's color, or undefined when covering all sports. */
+export function toolPrimarySport(tool: { sports: [SportKey, ...SportKey[]] }) {
+  return isAllSports(tool) ? null : Sports[tool.sports[0]];
+}
 
 export type Event = {
   id: number;
@@ -18,7 +31,7 @@ export type Tool = {
   id: string;
   nameKey: LangKey;
   descKey: LangKey;
-  sports: SportKey[];
+  sports: [SportKey, ...SportKey[]];
   icon: string;
 };
 

--- a/src/overlays/ToolDetail.tsx
+++ b/src/overlays/ToolDetail.tsx
@@ -48,28 +48,33 @@ const TOOL_BODIES: Record<string, React.ReactNode> = {
 export function ToolDetail({ tool, onBack }: Props) {
   const t = useT();
   const colors = useColors();
-  const sport = Sports[tool.sport as SportKey];
+  const allSports = ['run', 'bike', 'swim', 'tri'] as SportKey[];
+  const isAll = allSports.every((s) => tool.sports.includes(s));
+  const primarySport = isAll ? null : Sports[tool.sports[0]];
+  const accentColor = primarySport?.color ?? colors.accent;
+  const sportLabels: Record<string, string> = {
+    run: t('sport_run'), bike: t('sport_bike'), swim: t('sport_swim'), tri: t('sport_tri'),
+  };
 
   const badge = (
     <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6, marginBottom: 6 }}>
-      <AppText size={15}>{sport.icon}</AppText>
-      <AppText
-        condensed
-        weight="black"
-        size={11}
-        color={sport.color}
-        style={{ letterSpacing: 1.5 }}
-        uppercase>
-        {(
-          {
-            all: t('sport_all'),
-            swim: t('sport_swim'),
-            bike: t('sport_bike'),
-            run: t('sport_run'),
-            tri: t('sport_tri'),
-          } as Record<string, string>
-        )[tool.sport]}
-      </AppText>
+      {isAll ? (
+        <>
+          <AppText size={15}>⚡</AppText>
+          <AppText condensed weight="black" size={11} color={accentColor} style={{ letterSpacing: 1.5 }} uppercase>
+            {t('sport_all')}
+          </AppText>
+        </>
+      ) : (
+        tool.sports.map((s) => (
+          <View key={s} style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+            <AppText size={13}>{Sports[s].icon}</AppText>
+            <AppText condensed weight="black" size={11} color={Sports[s].color} style={{ letterSpacing: 1.5 }} uppercase>
+              {sportLabels[s]}
+            </AppText>
+          </View>
+        ))
+      )}
     </View>
   );
 

--- a/src/overlays/ToolDetail.tsx
+++ b/src/overlays/ToolDetail.tsx
@@ -3,9 +3,9 @@ import { View } from 'react-native';
 import { AppText } from '../components/AppText';
 import { Overlay } from '../components/Overlay';
 import { useColors } from '../context/ThemeContext';
-import type { Tool } from '../data';
+import { isAllSports, toolPrimarySport, type Tool } from '../data';
 import { useT } from '../i18n';
-import { Sports, type SportKey } from '../theme';
+import { Sports } from '../theme';
 import { CadenceBeeper } from '../tools/CadenceBeeper';
 import { CalorieBurn } from '../tools/CalorieBurn';
 import { HRZones } from '../tools/HRZones';
@@ -48,9 +48,8 @@ const TOOL_BODIES: Record<string, React.ReactNode> = {
 export function ToolDetail({ tool, onBack }: Props) {
   const t = useT();
   const colors = useColors();
-  const allSports = ['run', 'bike', 'swim', 'tri'] as SportKey[];
-  const isAll = allSports.every((s) => tool.sports.includes(s));
-  const primarySport = isAll ? null : Sports[tool.sports[0]];
+  const isAll = isAllSports(tool);
+  const primarySport = toolPrimarySport(tool);
   const accentColor = primarySport?.color ?? colors.accent;
   const sportLabels: Record<string, string> = {
     run: t('sport_run'), bike: t('sport_bike'), swim: t('sport_swim'), tri: t('sport_tri'),

--- a/src/screens/ToolsScreen.tsx
+++ b/src/screens/ToolsScreen.tsx
@@ -80,7 +80,7 @@ export function ToolsScreen({ onSelect }: Props) {
   const styles = useMemo(() => makeStyles(colors), [colors]);
   const [activeTab, setActiveTab] = useState<TabId>('all');
 
-  const filtered = activeTab === 'all' ? TOOLS : TOOLS.filter((tool) => tool.sport === activeTab);
+  const filtered = activeTab === 'all' ? TOOLS : TOOLS.filter((tool) => tool.sports.includes(activeTab as SportKey));
 
   return (
     <View style={styles.container}>
@@ -102,7 +102,7 @@ export function ToolsScreen({ onSelect }: Props) {
           const sport =
             tab.id === 'all' ? { icon: '⚡', color: colors.accent } : Sports[tab.id as SportKey];
           const count =
-            tab.id === 'all' ? TOOLS.length : TOOLS.filter((tool) => tool.sport === tab.id).length;
+            tab.id === 'all' ? TOOLS.length : TOOLS.filter((tool) => tool.sports.includes(tab.id as SportKey)).length;
           const active = activeTab === tab.id;
           return (
             <Pressable
@@ -134,14 +134,14 @@ export function ToolsScreen({ onSelect }: Props) {
 
       <ScrollView style={styles.list} contentContainerStyle={styles.listContent}>
         {filtered.map((tool) => {
-          const sport =
-            tool.sport === 'all'
-              ? { icon: '⚡', color: colors.accent, bg: '#1a1a0a' }
-              : Sports[tool.sport as SportKey];
+          const allSports = ['run', 'bike', 'swim', 'tri'] as SportKey[];
+          const isAll = allSports.every((s) => tool.sports.includes(s));
+          const primarySport = isAll ? null : Sports[tool.sports[0]];
+          const accentColor = primarySport ? primarySport.color : colors.accent;
           return (
             <Pressable key={tool.id} style={styles.toolCard} onPress={() => onSelect(tool)}>
-              <View style={[styles.stripe, { backgroundColor: sport.color }]} />
-              <View style={[styles.toolIcon, { backgroundColor: `${sport.color}22` }]}>
+              <View style={[styles.stripe, { backgroundColor: accentColor }]} />
+              <View style={[styles.toolIcon, { backgroundColor: `${accentColor}22` }]}>
                 <AppText size={20}>{tool.icon}</AppText>
               </View>
               <View style={styles.toolInfo}>
@@ -149,25 +149,17 @@ export function ToolsScreen({ onSelect }: Props) {
                   <AppText condensed weight="bold" size={16} style={{ flex: 1 }}>
                     {t(tool.nameKey)}
                   </AppText>
-                  <View style={[styles.tagBadge, { backgroundColor: `${sport.color}22` }]}>
+                  <View style={[styles.tagBadge, { backgroundColor: `${accentColor}22` }]}>
                     <AppText
                       condensed
                       weight="bold"
                       size={10}
-                      color={sport.color}
+                      color={accentColor}
                       uppercase
                       style={{ letterSpacing: 0.5 }}>
-                      {
-                        (
-                          {
-                            Run: t('sport_run'),
-                            Bike: t('sport_bike'),
-                            Swim: t('sport_swim'),
-                            Tri: t('sport_tri'),
-                            All: t('sport_all'),
-                          } as Record<string, string>
-                        )[tool.tag]
-                      }
+                      {isAll
+                        ? t('sport_all')
+                        : tool.sports.map((s) => Sports[s].icon).join(' ')}
                     </AppText>
                   </View>
                 </View>

--- a/src/screens/ToolsScreen.tsx
+++ b/src/screens/ToolsScreen.tsx
@@ -3,7 +3,7 @@ import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
 
 import { AppText } from '../components/AppText';
 import { useColors } from '../context/ThemeContext';
-import { TOOLS, type Tool } from '../data';
+import { isAllSports, toolPrimarySport, TOOLS, type Tool } from '../data';
 import { useT } from '../i18n';
 import { type ColorPalette, Font, Space, Sports, type SportKey } from '../theme';
 
@@ -134,10 +134,15 @@ export function ToolsScreen({ onSelect }: Props) {
 
       <ScrollView style={styles.list} contentContainerStyle={styles.listContent}>
         {filtered.map((tool) => {
-          const allSports = ['run', 'bike', 'swim', 'tri'] as SportKey[];
-          const isAll = allSports.every((s) => tool.sports.includes(s));
-          const primarySport = isAll ? null : Sports[tool.sports[0]];
+          const isAll = isAllSports(tool);
+          const primarySport = toolPrimarySport(tool);
           const accentColor = primarySport ? primarySport.color : colors.accent;
+          const sportLabels: Record<string, string> = {
+            run: t('sport_run'), bike: t('sport_bike'), swim: t('sport_swim'), tri: t('sport_tri'),
+          };
+          const badgeLabel = isAll
+            ? t('sport_all')
+            : tool.sports.map((s) => `${Sports[s].icon} ${sportLabels[s]}`).join(' · ');
           return (
             <Pressable key={tool.id} style={styles.toolCard} onPress={() => onSelect(tool)}>
               <View style={[styles.stripe, { backgroundColor: accentColor }]} />
@@ -157,9 +162,7 @@ export function ToolsScreen({ onSelect }: Props) {
                       color={accentColor}
                       uppercase
                       style={{ letterSpacing: 0.5 }}>
-                      {isAll
-                        ? t('sport_all')
-                        : tool.sports.map((s) => Sports[s].icon).join(' ')}
+                      {badgeLabel}
                     </AppText>
                   </View>
                 </View>


### PR DESCRIPTION
## Summary by Sourcery

Allow tools to be associated with multiple sports and update tool display and filtering accordingly.

New Features:
- Support assigning multiple sports to a single tool instead of a single sport or 'all'.

Enhancements:
- Update tool detail and list UIs to reflect multi-sport tools with dynamic badges, icons, and accent colors.
- Simplify tool metadata by removing the separate tag field and deriving sport labels from the sports list.